### PR TITLE
feat(pmp-web): add basic pages styles

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -891,6 +891,37 @@
           "styleext": "scss"
         }
       }
+    },
+    "pmp-web-shared-ui-go-back-header": {
+      "projectType": "library",
+      "root": "libs/pmp-web/shared/ui-go-back-header",
+      "sourceRoot": "libs/pmp-web/shared/ui-go-back-header/src",
+      "prefix": "pmp",
+      "architect": {
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": [
+              "libs/pmp-web/shared/ui-go-back-header/tsconfig.lib.json",
+              "libs/pmp-web/shared/ui-go-back-header/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/pmp-web/shared/ui-go-back-header/**"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/pmp-web/shared/ui-go-back-header/jest.config.js",
+            "tsConfig": "libs/pmp-web/shared/ui-go-back-header/tsconfig.spec.json",
+            "setupFile": "libs/pmp-web/shared/ui-go-back-header/src/test-setup.ts"
+          }
+        }
+      },
+      "schematics": {
+        "@nrwl/angular:component": {
+          "styleext": "scss"
+        }
+      }
     }
   },
   "cli": {

--- a/apps/pmp-web/src/styles.scss
+++ b/apps/pmp-web/src/styles.scss
@@ -25,7 +25,14 @@ $pmp-web-theme: mat-light-theme($pmp-web-primary, $pmp-web-accent, $pmp-web-warn
 // that you are using.
 @include angular-material-theme($pmp-web-theme);
 
-body,
-html {
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
   font-family: Roboto, 'Helvetica Neue', sans-serif;
+  // TODO: move to SCSS variable
+  background-color: #eef1f6;
 }

--- a/libs/pmp-web/repository/repositories-statistics/feature/src/lib/containers/repositories-statistics/repositories-statistics.component.html
+++ b/libs/pmp-web/repository/repositories-statistics/feature/src/lib/containers/repositories-statistics/repositories-statistics.component.html
@@ -1,4 +1,9 @@
-<pmp-statistics-overview-table
-  (navigateToItem)="onNavigateToRepository($event)"
-  [data]="repositoryStatisticsCollection$ | async"
-></pmp-statistics-overview-table>
+<div class="page__content">
+  <h1 class="page__title">Projects with PRs pending</h1>
+
+  <pmp-statistics-overview-table
+    class="repositories-table"
+    (navigateToItem)="onNavigateToRepository($event)"
+    [data]="repositoryStatisticsCollection$ | async"
+  ></pmp-statistics-overview-table>
+</div>

--- a/libs/pmp-web/repository/repositories-statistics/feature/src/lib/containers/repositories-statistics/repositories-statistics.component.scss
+++ b/libs/pmp-web/repository/repositories-statistics/feature/src/lib/containers/repositories-statistics/repositories-statistics.component.scss
@@ -1,11 +1,17 @@
-:host {
-  height: 100%;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+// TODO: share styles between repositories statisics and users statistics
+.page__title {
+  font-size: 24px;
+  font-weight: 400;
+  margin-bottom: 35px;
 }
 
-pmp-statistics-overview-table {
-  width: 80%;
+.page__content {
+  width: 90%;
+  max-width: 1400px;
+  margin: auto;
+  padding: 40px 0;
+}
+
+.repositories-table {
+  width: 100%;
 }

--- a/libs/pmp-web/repository/shell/src/lib/containers/repositories/repositories.component.scss
+++ b/libs/pmp-web/repository/shell/src/lib/containers/repositories/repositories.component.scss
@@ -1,6 +1,5 @@
 .repositories-component__container {
-  background-color: #eef1f6;
-  height: 100vh;
+  margin: 64px 0 0 60px;
 }
 
 .navbar {

--- a/libs/pmp-web/repository/shell/src/lib/containers/repositories/repositories.component.ts
+++ b/libs/pmp-web/repository/shell/src/lib/containers/repositories/repositories.component.ts
@@ -1,10 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
   selector: 'pmp-repositories',
   templateUrl: './repositories.component.html',
-  styleUrls: ['./repositories.component.scss']
+  styleUrls: ['./repositories.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class RepositoriesComponent {
-  constructor() {}
-}
+export class RepositoriesComponent {}

--- a/libs/pmp-web/repository/shell/src/lib/pmp-web-repository-shell.module.ts
+++ b/libs/pmp-web/repository/shell/src/lib/pmp-web-repository-shell.module.ts
@@ -1,9 +1,10 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ShellRoutingModule } from './shell-routing.module';
-import { RepositoriesComponent } from './containers/repositories/repositories.component';
 import { PmpWebSharedUiNavbarModule } from '@pimp-my-pr/pmp-web/shared/ui-navbar';
 import { PmpWebSharedUiSidebarModule } from '@pimp-my-pr/pmp-web/shared/ui-sidebar';
+
+import { RepositoriesComponent } from './containers/repositories/repositories.component';
+import { ShellRoutingModule } from './shell-routing.module';
 
 @NgModule({
   imports: [

--- a/libs/pmp-web/shared/ui-go-back-header/README.md
+++ b/libs/pmp-web/shared/ui-go-back-header/README.md
@@ -1,0 +1,7 @@
+# pmp-web-shared-ui-go-back-header
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test pmp-web-shared-ui-go-back-header` to execute the unit tests.

--- a/libs/pmp-web/shared/ui-go-back-header/jest.config.js
+++ b/libs/pmp-web/shared/ui-go-back-header/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'pmp-web-shared-ui-go-back-header',
+  preset: '../../../../jest.config.js',
+  coverageDirectory: '../../../../coverage/libs/pmp-web/shared/ui-go-back-header',
+  snapshotSerializers: [
+    'jest-preset-angular/AngularSnapshotSerializer.js',
+    'jest-preset-angular/HTMLCommentSerializer.js'
+  ]
+};

--- a/libs/pmp-web/shared/ui-go-back-header/src/index.ts
+++ b/libs/pmp-web/shared/ui-go-back-header/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/pmp-web-shared-ui-go-back-header.module';
+export * from './lib/components/go-back-header/go-back-header.component';

--- a/libs/pmp-web/shared/ui-go-back-header/src/lib/components/go-back-header/go-back-header.component.html
+++ b/libs/pmp-web/shared/ui-go-back-header/src/lib/components/go-back-header/go-back-header.component.html
@@ -1,0 +1,7 @@
+<a [routerLink]="link" class="link">
+  <mat-icon>arrow_back</mat-icon>
+
+  <span class="link__text">
+    <ng-content></ng-content>
+  </span>
+</a>

--- a/libs/pmp-web/shared/ui-go-back-header/src/lib/components/go-back-header/go-back-header.component.scss
+++ b/libs/pmp-web/shared/ui-go-back-header/src/lib/components/go-back-header/go-back-header.component.scss
@@ -1,0 +1,20 @@
+:host {
+  display: block;
+  // TODO: move color to variable
+  background-color: #6ba5c6;
+  box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.2);
+  padding: 16px;
+}
+
+.link {
+  color: #fff;
+  font-size: 18px;
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+.link__text {
+  display: inline-block;
+  margin-left: 16px;
+}

--- a/libs/pmp-web/shared/ui-go-back-header/src/lib/components/go-back-header/go-back-header.component.ts
+++ b/libs/pmp-web/shared/ui-go-back-header/src/lib/components/go-back-header/go-back-header.component.ts
@@ -1,0 +1,11 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'pmp-go-back-header',
+  templateUrl: './go-back-header.component.html',
+  styleUrls: ['./go-back-header.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class GoBackHeaderComponent {
+  @Input() link: string;
+}

--- a/libs/pmp-web/shared/ui-go-back-header/src/lib/pmp-web-shared-ui-go-back-header.module.spec.ts
+++ b/libs/pmp-web/shared/ui-go-back-header/src/lib/pmp-web-shared-ui-go-back-header.module.spec.ts
@@ -1,0 +1,14 @@
+import { async, TestBed } from '@angular/core/testing';
+import { PmpWebSharedUiGoBackHeaderModule } from './pmp-web-shared-ui-go-back-header.module';
+
+describe('PmpWebSharedUiGoBackHeaderModule', () => {
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [PmpWebSharedUiGoBackHeaderModule]
+    }).compileComponents();
+  }));
+
+  it('should create', () => {
+    expect(PmpWebSharedUiGoBackHeaderModule).toBeDefined();
+  });
+});

--- a/libs/pmp-web/shared/ui-go-back-header/src/lib/pmp-web-shared-ui-go-back-header.module.ts
+++ b/libs/pmp-web/shared/ui-go-back-header/src/lib/pmp-web-shared-ui-go-back-header.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material';
+import { RouterModule } from '@angular/router';
+
+import { GoBackHeaderComponent } from './components/go-back-header/go-back-header.component';
+
+@NgModule({
+  imports: [CommonModule, MatIconModule, RouterModule],
+  declarations: [GoBackHeaderComponent],
+  exports: [GoBackHeaderComponent]
+})
+export class PmpWebSharedUiGoBackHeaderModule {}

--- a/libs/pmp-web/shared/ui-go-back-header/src/test-setup.ts
+++ b/libs/pmp-web/shared/ui-go-back-header/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular';

--- a/libs/pmp-web/shared/ui-go-back-header/tsconfig.json
+++ b/libs/pmp-web/shared/ui-go-back-header/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/libs/pmp-web/shared/ui-go-back-header/tsconfig.lib.json
+++ b/libs/pmp-web/shared/ui-go-back-header/tsconfig.lib.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "target": "es2015",
+    "declaration": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": ["dom", "es2018"]
+  },
+  "angularCompilerOptions": {
+    "annotateForClosureCompiler": true,
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true,
+    "enableResourceInlining": true
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts"]
+}

--- a/libs/pmp-web/shared/ui-go-back-header/tsconfig.spec.json
+++ b/libs/pmp-web/shared/ui-go-back-header/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/pmp-web/shared/ui-go-back-header/tslint.json
+++ b/libs/pmp-web/shared/ui-go-back-header/tslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../tslint.json",
+  "rules": {
+    "directive-selector": [true, "attribute", "pmp", "camelCase"],
+    "component-selector": [true, "element", "pmp", "kebab-case"]
+  }
+}

--- a/libs/pmp-web/shared/ui-statistics-overview-table/src/lib/statistics-overview-table/statistics-overview-table.component.scss
+++ b/libs/pmp-web/shared/ui-statistics-overview-table/src/lib/statistics-overview-table/statistics-overview-table.component.scss
@@ -8,10 +8,14 @@ mat-header-cell > span > mat-icon {
   color: #000000;
 }
 
+mat-cell {
+  padding: 0 5px;
+}
+
 .avatar-column {
   flex: unset;
-  padding-left: 30px;
   width: 62px;
+  padding: 0 0 0 5px;
 }
 
 .link-column {
@@ -28,4 +32,5 @@ mat-header-cell > span > mat-icon {
   height: 32px;
   background: gray;
   border-radius: 50%;
+  margin: auto;
 }

--- a/libs/pmp-web/user/shell/src/lib/containers/user/user.component.html
+++ b/libs/pmp-web/user/shell/src/lib/containers/user/user.component.html
@@ -1,7 +1,5 @@
 <div class="user-component__container">
   <pmp-navbar class="navbar"></pmp-navbar>
   <pmp-sidebar class="sidebar"></pmp-sidebar>
-  <div class="router-outlet__wrapper">
-    <router-outlet></router-outlet>
-  </div>
+  <router-outlet></router-outlet>
 </div>

--- a/libs/pmp-web/user/shell/src/lib/containers/user/user.component.scss
+++ b/libs/pmp-web/user/shell/src/lib/containers/user/user.component.scss
@@ -1,6 +1,6 @@
+// TODO: share between user and repistory shells?
 .user-component__container {
-  background-color: #eef1f6;
-  height: 500px;
+  margin: 64px 0 0 60px;
 }
 
 .navbar {
@@ -20,11 +20,4 @@
   width: 60px;
   overflow-x: hidden;
   box-shadow: 0 1px 2px rgb(0, 0, 0, 0.2);
-}
-
-.router-outlet__wrapper {
-  position: absolute;
-  left: 60px;
-  top: 64px;
-  right: 0;
 }

--- a/libs/pmp-web/user/shell/src/lib/pmp-web-user-shell.module.ts
+++ b/libs/pmp-web/user/shell/src/lib/pmp-web-user-shell.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+
 import { ShellRoutingModule } from './shell-routing.module';
 import { UserComponent } from './containers/user/user.component';
 import { PmpWebSharedUiNavbarModule } from '@pimp-my-pr/pmp-web/shared/ui-navbar';

--- a/libs/pmp-web/user/shell/src/lib/shell-routing.module.ts
+++ b/libs/pmp-web/user/shell/src/lib/shell-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+
 import { UserComponent } from './containers/user/user.component';
 
 const routes: Routes = [

--- a/libs/pmp-web/user/single-user-statistics/feature/src/lib/components/single-user-statistics-table/single-user-statistics-table.component.scss
+++ b/libs/pmp-web/user/single-user-statistics/feature/src/lib/components/single-user-statistics-table/single-user-statistics-table.component.scss
@@ -21,3 +21,8 @@
     margin: 0 0.3em 0 0;
   }
 }
+
+mat-header-cell,
+mat-cell {
+  padding: 0 5px;
+}

--- a/libs/pmp-web/user/single-user-statistics/feature/src/lib/containers/single-user-statistics/single-user-statistics.component.html
+++ b/libs/pmp-web/user/single-user-statistics/feature/src/lib/containers/single-user-statistics/single-user-statistics.component.html
@@ -1,15 +1,20 @@
+<pmp-go-back-header link="/user">Projects with PRs pending</pmp-go-back-header>
+
 <div class="user-statistics__container" *ngIf="userStatistics">
   <div class="user-statistics__header-container">
     <h2 class="user-statistics__header-label">Pull requests pending</h2>
+
     <pmp-picture-label
       [label]="userStatistics.name"
       [picture]="userStatistics.avatarUrl"
     ></pmp-picture-label>
   </div>
+
   <div *ngFor="let repo of userStatistics.repositories">
     <div class="user-statistics__repository-label">
       <pmp-picture-label [label]="repo.name" [picture]="repo.pictureUrl"> </pmp-picture-label>
     </div>
+
     <pmp-single-user-statistics-table
       [tableData]="repo.prsStatistics"
     ></pmp-single-user-statistics-table>

--- a/libs/pmp-web/user/single-user-statistics/feature/src/lib/containers/single-user-statistics/single-user-statistics.component.scss
+++ b/libs/pmp-web/user/single-user-statistics/feature/src/lib/containers/single-user-statistics/single-user-statistics.component.scss
@@ -1,13 +1,8 @@
-:host {
-  height: 100%;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
 .user-statistics__container {
+  padding: 40px 0;
   width: 90%;
+  max-width: 1400px;
+  margin: auto;
 }
 
 .user-statistics__repository-label {
@@ -17,7 +12,7 @@
 .user-statistics__header-container {
   display: flex;
   align-items: center;
-  margin: 2em 0;
+  margin-bottom: 2em;
 }
 
 .user-statistics__header-label {

--- a/libs/pmp-web/user/single-user-statistics/feature/src/lib/pmp-web-user-single-user-statistics-feature.module.ts
+++ b/libs/pmp-web/user/single-user-statistics/feature/src/lib/pmp-web-user-single-user-statistics-feature.module.ts
@@ -6,6 +6,7 @@ import { PmpWebSharedUiPictureLabelModule } from '@pimp-my-pr/pmp-web/shared/ui-
 import { SingleUserStatisticsTableComponent } from './components/single-user-statistics-table/single-user-statistics-table.component';
 import { MatIconModule, MatTableModule } from '@angular/material';
 import { PmpWebUserSingleUserStatisticsDataAccessModule } from '@pimp-my-pr/pmp-web/user/single-user-statistics/data-access';
+import { PmpWebSharedUiGoBackHeaderModule } from '@pimp-my-pr/pmp-web/shared/ui-go-back-header';
 
 @NgModule({
   imports: [
@@ -14,7 +15,8 @@ import { PmpWebUserSingleUserStatisticsDataAccessModule } from '@pimp-my-pr/pmp-
     PmpWebSharedUiPictureLabelModule,
     PmpWebUserSingleUserStatisticsDataAccessModule,
     MatTableModule,
-    MatIconModule
+    MatIconModule,
+    PmpWebSharedUiGoBackHeaderModule
   ],
   declarations: [SingleUserStatisticsComponent, SingleUserStatisticsTableComponent]
 })

--- a/libs/pmp-web/user/users-statistics/feature/src/lib/containers/users-statistics/users-statistics.component.html
+++ b/libs/pmp-web/user/users-statistics/feature/src/lib/containers/users-statistics/users-statistics.component.html
@@ -1,4 +1,9 @@
-<pmp-statistics-overview-table
-  [data]="userStatisticsCollection$ | async"
-  (navigateToItem)="onNavigateToUser($event)"
-></pmp-statistics-overview-table>
+<div class="page__content">
+  <h1 class="page__title">Repository users with PRs pending</h1>
+
+  <pmp-statistics-overview-table
+    class="users-table"
+    [data]="userStatisticsCollection$ | async"
+    (navigateToItem)="onNavigateToUser($event)"
+  ></pmp-statistics-overview-table>
+</div>

--- a/libs/pmp-web/user/users-statistics/feature/src/lib/containers/users-statistics/users-statistics.component.scss
+++ b/libs/pmp-web/user/users-statistics/feature/src/lib/containers/users-statistics/users-statistics.component.scss
@@ -1,11 +1,17 @@
-:host {
-  height: 100%;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+// TODO: share styles between repositories statisics and users statistics
+.page__title {
+  font-size: 24px;
+  font-weight: 400;
+  margin-bottom: 35px;
 }
 
-pmp-statistics-overview-table {
-  width: 80%;
+.page__content {
+  width: 90%;
+  max-width: 1400px;
+  margin: auto;
+  padding: 40px 0;
+}
+
+.users-table {
+  width: 100%;
 }

--- a/nx.json
+++ b/nx.json
@@ -91,6 +91,9 @@
     },
     "pmp-web-shared-ui-statistics-overview-table": {
       "tags": ["scope:pmp-web-shared", "type:ui"]
+    },
+    "pmp-web-shared-ui-go-back-header": {
+      "tags": ["scope:pmp-web-shared", "type:ui"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,6 +65,9 @@
       ],
       "@pimp-my-pr/pmp-web/shared/ui-statistics-overview-table": [
         "libs/pmp-web/shared/ui-statistics-overview-table/src/index.ts"
+      ],
+      "@pimp-my-pr/pmp-web/shared/ui-go-back-header": [
+        "libs/pmp-web/shared/ui-go-back-header/src/index.ts"
       ]
     }
   },


### PR DESCRIPTION
Add styles for /user, /repositories and /user/:id pages.
Add previous page header in /user/:id page.

resolve #PMP-79