### PR TITLE
build(pmp-api): minimize api image

### DIFF
--- a/apps/pmp-api/Dockerfile
+++ b/apps/pmp-api/Dockerfile
@@ -1,22 +1,24 @@
-ARG NODE_VERSION=12.16.1-stretch
-FROM node:${NODE_VERSION} as modules
-
-COPY package.json package-lock.json ./
-
-RUN npm ci
-
-FROM node:${NODE_VERSION}
+ARG NODE_VERSION=12.16.1
+FROM node:${NODE_VERSION}-stretch as modules
 
 WORKDIR /app
 
-COPY --from=modules node_modules node_modules
+COPY angular.json nx.json package.json package-lock.json tsconfig.json ./
+COPY ./libs/shared ./libs/shared
+COPY ./libs/server ./libs/server
+COPY ./apps/pmp-api ./apps/pmp-api
 
-COPY angular.json nx.json package.json package-lock.json tsconfig.json /app/
-COPY ./libs/shared /app/libs/shared
-COPY ./libs/server /app/libs/server
-COPY ./apps/pmp-api /app/apps/pmp-api
-
+RUN npm ci
 RUN npm run build:pmp-api:prod
+
+FROM node:${NODE_VERSION}-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY --from=modules /app/dist/apps/pmp-api/main.js main.js
+
+RUN npm ci --prod
 
 EXPOSE 3333
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format:write": "nx format:write",
     "format:check": "nx format:check",
     "init": "node ./scripts/init.js",
-    "run:pmp-api": "pm2 start dist/apps/pmp-api/main.js --no-daemon",
+    "run:pmp-api": "pm2 start main.js --no-daemon",
     "update": "ng update @nrwl/workspace",
     "update:check": "ng update",
     "workspace-schematic": "nx workspace-schematic",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/valueadd-poland/pimp-my-pr/blob/master/CONTRIBUTING.md#git-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
Locally I noticed that the API image has the size of 1GB

Issue Number: N/A

## What is the new behavior?
Locally the API image has the size of 350MB

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Can be still improved by removing angular dependencies, but it can't be easily achieved because of valueadd-poland/valueadd#54
Additionally, we can choose a different way to achieve a smaller bundle size. We need to check the result of [this](https://stackoverflow.com/questions/61544877/why-node-js-application-shouldnt-be-bandled-into-a-single-js-file-but-pkg-works) question 