### PR TITLE
refactor(pmp-api): get rid of entities in controllers

### DIFF
--- a/apps/pmp-api-e2e/integration/repository.spec.ts
+++ b/apps/pmp-api-e2e/integration/repository.spec.ts
@@ -92,13 +92,11 @@ describe('Repository', () => {
         .expect(200, {
           data: [
             {
-              prs: [],
               id: '22123383112345',
               repositoryId: '221233831',
               name: 'pimp-my-pr',
               owner: 'valueadd-poland',
               pictureUrl: 'https://avatars1.githubusercontent.com/u/49273957?v=4',
-              userId: '12345',
               maxWaitingTime: null,
               maxLines: null
             }

--- a/libs/server/repository/api-rest/src/lib/controllers/repository.controller.ts
+++ b/libs/server/repository/api-rest/src/lib/controllers/repository.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Delete, Get, Param, Post, Put, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import {
   AuthGuard,
   Credentials,
@@ -11,9 +11,9 @@ import {
   AddRepositoryCommand,
   DeleteRepositoryCommand,
   EditRepositoryCommand,
-  RepositoryFacade
+  RepositoryFacade,
+  ListRepositoriesReadModel
 } from '@pimp-my-pr/server/repository/core/application-services';
-import { RepositoryEntity } from '@pimp-my-pr/server/repository/core/domain';
 import { extractFullName } from '@pimp-my-pr/server/shared/util-repository';
 import { AddRepositoryDto } from '../dtos/add-repository.dto';
 import { UserRepositoryGuard } from '../guards/user-repository.guard';
@@ -27,7 +27,8 @@ export class RepositoryController {
   constructor(private repositoryFacade: RepositoryFacade) {}
 
   @Get()
-  list(@CurrentUserId() currentUserId: string): Promise<RepositoryEntity[]> {
+  @ApiOkResponse({ type: [ListRepositoriesReadModel] })
+  list(@CurrentUserId() currentUserId: string): Promise<ListRepositoriesReadModel[]> {
     return this.repositoryFacade.listRepositories(currentUserId);
   }
 

--- a/libs/server/repository/core/application-services/src/index.ts
+++ b/libs/server/repository/core/application-services/src/index.ts
@@ -8,4 +8,5 @@ export * from './lib/queries/list-repositories-statistics/repositories-statistic
 export * from './lib/read-models/reviewer-model-with-pr.interface';
 export * from './lib/commands/add-repository/add-repository.command';
 export * from './lib/commands/delete-repository/delete-repository.command';
+export * from './lib/queries/list-repositories/list-repositories.read-model';
 export * from './lib/commands/edit-repository/edit-repository.command';

--- a/libs/server/repository/core/application-services/src/lib/queries/list-repositories/list-repositories.handler.ts
+++ b/libs/server/repository/core/application-services/src/lib/queries/list-repositories/list-repositories.handler.ts
@@ -1,14 +1,17 @@
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
-import { RepositoryEntity } from '@pimp-my-pr/server/repository/core/domain';
 import { RepositoryRepository } from '@pimp-my-pr/server/repository/core/domain-services';
 import { ListRepositoriesQuery } from './list-repositories.query';
+import { listRepositoriesReadModelFactory } from '../../read-models/factories/list-repositories-read-model.factory';
+import { ListRepositoriesReadModel } from './list-repositories.read-model';
 
 @QueryHandler(ListRepositoriesQuery)
 export class ListRepositoriesHandler
-  implements IQueryHandler<ListRepositoriesQuery, RepositoryEntity[]> {
+  implements IQueryHandler<ListRepositoriesQuery, ListRepositoriesReadModel[]> {
   constructor(private repositoryRepository: RepositoryRepository) {}
 
-  async execute(query: ListRepositoriesQuery): Promise<RepositoryEntity[]> {
-    return this.repositoryRepository.findByUserId(query.currentUserId);
+  async execute(query: ListRepositoriesQuery): Promise<ListRepositoriesReadModel[]> {
+    const repositories = await this.repositoryRepository.findByUserId(query.currentUserId);
+
+    return repositories.map(repository => listRepositoriesReadModelFactory(repository));
   }
 }

--- a/libs/server/repository/core/application-services/src/lib/queries/list-repositories/list-repositories.read-model.ts
+++ b/libs/server/repository/core/application-services/src/lib/queries/list-repositories/list-repositories.read-model.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ListRepositoriesReadModel {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  maxLines?: number;
+
+  @ApiProperty()
+  maxWaitingTime?: number;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  owner: string;
+
+  @ApiProperty()
+  pictureUrl: string;
+
+  @ApiProperty()
+  repositoryId: string;
+}

--- a/libs/server/repository/core/application-services/src/lib/read-models/author.read-model.ts
+++ b/libs/server/repository/core/application-services/src/lib/read-models/author.read-model.ts
@@ -1,0 +1,3 @@
+import { ContributorReadModel } from './contributor.read-model';
+
+export class AuthorReadModel extends ContributorReadModel {}

--- a/libs/server/repository/core/application-services/src/lib/read-models/contributor.read-model.ts
+++ b/libs/server/repository/core/application-services/src/lib/read-models/contributor.read-model.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export abstract class ContributorReadModel {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  avatarUrl: string;
+
+  @ApiProperty()
+  contributions?: number;
+}

--- a/libs/server/repository/core/application-services/src/lib/read-models/factories/author-read-model.factory.ts
+++ b/libs/server/repository/core/application-services/src/lib/read-models/factories/author-read-model.factory.ts
@@ -1,0 +1,12 @@
+import { AuthorEntity } from '@pimp-my-pr/server/repository/core/domain';
+import { AuthorReadModel } from '../author.read-model';
+
+export const authorReadModelFactory = (authorEntity: AuthorEntity): AuthorReadModel => {
+  const authorReadModel = new AuthorReadModel();
+
+  authorReadModel.id = authorEntity.id;
+  authorReadModel.name = authorEntity.name;
+  authorReadModel.avatarUrl = authorEntity.avatarUrl;
+
+  return authorReadModel;
+};

--- a/libs/server/repository/core/application-services/src/lib/read-models/factories/list-repositories-read-model.factory.ts
+++ b/libs/server/repository/core/application-services/src/lib/read-models/factories/list-repositories-read-model.factory.ts
@@ -1,0 +1,18 @@
+import { RepositoryEntity } from '@pimp-my-pr/server/repository/core/domain';
+import { ListRepositoriesReadModel } from '../../queries/list-repositories/list-repositories.read-model';
+
+export const listRepositoriesReadModelFactory = (
+  repository: RepositoryEntity
+): ListRepositoriesReadModel => {
+  const listRepositoriesReadModel = new ListRepositoriesReadModel();
+
+  listRepositoriesReadModel.id = repository.id;
+  listRepositoriesReadModel.maxLines = repository.maxLines;
+  listRepositoriesReadModel.maxWaitingTime = repository.maxWaitingTime;
+  listRepositoriesReadModel.name = repository.name;
+  listRepositoriesReadModel.owner = repository.owner;
+  listRepositoriesReadModel.pictureUrl = repository.pictureUrl;
+  listRepositoriesReadModel.repositoryId = repository.repositoryId;
+
+  return listRepositoriesReadModel;
+};

--- a/libs/server/repository/core/application-services/src/lib/read-models/factories/pr-read-model.factory.ts
+++ b/libs/server/repository/core/application-services/src/lib/read-models/factories/pr-read-model.factory.ts
@@ -1,0 +1,24 @@
+import { PrEntity } from '@pimp-my-pr/server/repository/core/domain';
+import { PrReadModel } from '../pr.read-model';
+import { authorReadModelFactory } from './author-read-model.factory';
+import { reviewerReadModelFactory } from './reviewer-read-model.factory';
+
+export const prReadModelFactory = (prEntity: PrEntity): PrReadModel => {
+  const prReadModel = new PrReadModel();
+
+  prReadModel.additions = prEntity.additions;
+  prReadModel.author = authorReadModelFactory(prEntity.author);
+  prReadModel.changedFiles = prEntity.changedFiles;
+  prReadModel.closedAt = prEntity.closedAt;
+  prReadModel.commentsCount = prEntity.commentsCount;
+  prReadModel.createdAt = prEntity.createdAt;
+  prReadModel.deletions = prEntity.deletions;
+  prReadModel.id = prEntity.id;
+  prReadModel.reviewers = prEntity.reviewers.map(reviewer => reviewerReadModelFactory(reviewer));
+  prReadModel.state = prEntity.state;
+  prReadModel.title = prEntity.title;
+  prReadModel.updatedAt = prEntity.updatedAt;
+  prReadModel.url = prEntity.url;
+
+  return prReadModel;
+};

--- a/libs/server/repository/core/application-services/src/lib/read-models/factories/reviewer-read-model.factory.ts
+++ b/libs/server/repository/core/application-services/src/lib/read-models/factories/reviewer-read-model.factory.ts
@@ -1,0 +1,12 @@
+import { ReviewerEntity } from '@pimp-my-pr/server/repository/core/domain';
+import { ReviewerReadModel } from '../reviewer.read-model';
+
+export const reviewerReadModelFactory = (reviewerEntity: ReviewerEntity): ReviewerReadModel => {
+  const reviewerReadModel = new ReviewerReadModel();
+
+  reviewerReadModel.id = reviewerEntity.id;
+  reviewerReadModel.name = reviewerEntity.name;
+  reviewerReadModel.avatarUrl = reviewerEntity.avatarUrl;
+
+  return reviewerReadModel;
+};

--- a/libs/server/repository/core/application-services/src/lib/read-models/pr-statistics.read-model.ts
+++ b/libs/server/repository/core/application-services/src/lib/read-models/pr-statistics.read-model.ts
@@ -1,9 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { AuthorEntity, PrEntity, ReviewerEntity } from '@pimp-my-pr/server/repository/core/domain';
+import { PrEntity } from '@pimp-my-pr/server/repository/core/domain';
+import { authorReadModelFactory } from './factories/author-read-model.factory';
+import { AuthorReadModel } from './author.read-model';
+import { ReviewerReadModel } from './reviewer.read-model';
+import { reviewerReadModelFactory } from './factories/reviewer-read-model.factory';
 
 export class PrStatisticsReadModel {
   @ApiProperty()
-  author: AuthorEntity;
+  author: AuthorReadModel;
   @ApiProperty()
   commentsCount: number;
   @ApiProperty()
@@ -12,8 +16,8 @@ export class PrStatisticsReadModel {
   id: string;
   @ApiProperty()
   linesOfCodeToCheck: number;
-  @ApiProperty({ type: [ReviewerEntity] })
-  reviewers: ReviewerEntity[];
+  @ApiProperty({ type: [ReviewerReadModel] })
+  reviewers: ReviewerReadModel[];
   @ApiProperty()
   timeWaiting: number;
   @ApiProperty()
@@ -28,9 +32,9 @@ export class PrStatisticsReadModel {
     this.linesOfCodeToCheck = pr.linesOfCodeToCheck;
     this.id = pr.id;
     this.title = pr.title;
-    this.author = pr.author;
+    this.author = authorReadModelFactory(pr.author);
     this.commentsCount = pr.commentsCount;
-    this.reviewers = pr.reviewers;
+    this.reviewers = pr.reviewers.map(reviewer => reviewerReadModelFactory(reviewer));
     this.url = pr.url;
     this.timeWaiting = this.getTimePrWaiting(pr.createdAt);
     this.timeWaitingFromLastChange = this.getTimePrWaiting(pr.updatedAt);

--- a/libs/server/repository/core/application-services/src/lib/read-models/pr.read-model.ts
+++ b/libs/server/repository/core/application-services/src/lib/read-models/pr.read-model.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AuthorReadModel } from './author.read-model';
+import { ReviewerReadModel } from './reviewer.read-model';
+
+export class PrReadModel {
+  @ApiProperty()
+  additions: number;
+  @ApiProperty()
+  author: AuthorReadModel;
+  @ApiProperty()
+  changedFiles: number;
+  @ApiProperty()
+  closedAt?: Date;
+  @ApiProperty()
+  commentsCount: number;
+  @ApiProperty()
+  createdAt: Date;
+  @ApiProperty()
+  deletions: number;
+  @ApiProperty()
+  id: string;
+  @ApiProperty()
+  reviewers: ReviewerReadModel[];
+  @ApiProperty()
+  state: 'open' | 'closed';
+  @ApiProperty()
+  title: string;
+  @ApiProperty()
+  updatedAt: Date;
+  @ApiProperty()
+  url: string;
+}

--- a/libs/server/repository/core/application-services/src/lib/read-models/reviewer.read-model.ts
+++ b/libs/server/repository/core/application-services/src/lib/read-models/reviewer.read-model.ts
@@ -1,0 +1,3 @@
+import { ContributorReadModel } from './contributor.read-model';
+
+export class ReviewerReadModel extends ContributorReadModel {}

--- a/libs/server/repository/core/application-services/src/lib/repository.facade.ts
+++ b/libs/server/repository/core/application-services/src/lib/repository.facade.ts
@@ -8,7 +8,6 @@ import {
   ReviewersStatisticsItemReadModel,
   ReviewerStatisticsReadModel
 } from '@pimp-my-pr/server/repository/core/application-services';
-import { RepositoryEntity } from '@pimp-my-pr/server/repository/core/domain';
 import { Platform } from '@pimp-my-pr/shared/domain';
 import { AddRepositoryCommand } from './commands/add-repository/add-repository.command';
 import { GetRepositoryStatisticsQuery } from './queries/get-repository-statistics/get-repository-statistics.query';
@@ -16,6 +15,7 @@ import { GetReviewerStatisticsQuery } from './queries/get-reviewer-statistics/ge
 import { ListRepositoriesStatisticsQuery } from './queries/list-repositories-statistics/list-repositories-statistics.query';
 import { ListRepositoriesQuery } from './queries/list-repositories/list-repositories.query';
 import { ListReviewersStatisticsQuery } from './queries/list-reviewers-statistics/list-reviewers-statistics.query';
+import { ListRepositoriesReadModel } from './queries/list-repositories/list-repositories.read-model';
 
 @Injectable()
 export class RepositoryFacade {
@@ -58,7 +58,7 @@ export class RepositoryFacade {
     return this.queryBus.execute(new ListRepositoriesStatisticsQuery(token, platform, userId));
   }
 
-  listRepositories(currentUserId: string): Promise<RepositoryEntity[]> {
+  listRepositories(currentUserId: string): Promise<ListRepositoriesReadModel[]> {
     return this.queryBus.execute(new ListRepositoriesQuery(currentUserId));
   }
 


### PR DESCRIPTION
Entity has been returned from one endpoint.
It is better to return read model there.

Resolve #224

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/valueadd-poland/pimp-my-pr/blob/master/CONTRIBUTING.md#git-guidelines
- [] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Controller returned an entity instead of read-model.

Issue Number: [#224 ](https://github.com/valueadd-poland/pimp-my-pr/issues/224)

## What is the new behavior?
Read-models are returned from all of api endpoints.
## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
